### PR TITLE
Added DOIs for datasets to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Schürz, M., Grigoropoulou, A., Garcia Marquez, J.R., Tomiczek, T., Floury, M., 
 
 Please also cite the Hydrography90m data:
 
-Amatulli, G., Garcia Marquez, J.R., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M., Shen, L., Domisch, S. (2022). Hydrography90m: A new high-resolution global hydrographic dataset. _Earth System Science Data_, 14, 4525–4550.
+Amatulli, G., Garcia Marquez, J.R., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M., Shen, L., Domisch, S. (2022). Hydrography90m: A new high-resolution global hydrographic dataset. _Earth System Science Data_, 14, 4525–4550, 10.5194/essd-14-4525-2022.
 
 If you're using the environmental data, please also cite the Environment90m data:
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ You can find more details on the package and its applications in our recently pu
 
 Please cite the hydrographr package as:
 
-Schürz, M., Grigoropoulou, A., Garcia Marquez, J.R., Tomiczek, T., Floury, M., Schürz, C., Amatulli, G., Grossart, H.-P., Domisch, S. (2023). hydrographr: an R package for scalable hydrographic data processing. _Methods in Ecology and Evolution_, 10.1111/2041-210X.14226
+Schürz, M., Grigoropoulou, A., Garcia Marquez, J.R., Tomiczek, T., Floury, M., Schürz, C., Amatulli, G., Grossart, H.-P., Domisch, S. (2023). hydrographr: an R package for scalable hydrographic data processing. _Methods in Ecology and Evolution_, [doi:10.1111/2041-210X.14226](https://doi.org/10.1111/2041-210X.14226).
 
 Please also cite the Hydrography90m data:
 
-Amatulli, G., Garcia Marquez, J.R., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M., Shen, L., Domisch, S. (2022). Hydrography90m: A new high-resolution global hydrographic dataset. _Earth System Science Data_, 14, 4525–4550, 10.5194/essd-14-4525-2022.
+Amatulli, G., Garcia Marquez, J.R., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M., Shen, L., Domisch, S. (2022). Hydrography90m: A new high-resolution global hydrographic dataset. _Earth System Science Data_, 14, 4525–4550, [doi:10.5194/essd-14-4525-2022](https://doi.org/10.5194/essd-14-4525-2022).
 
 If you're using the environmental data, please also cite the Environment90m data:
 


### PR DESCRIPTION
Two commits:

* Added the missing DOI for the `Hydrography90m` dataset, taken from the ESSD publication: https://essd.copernicus.org/articles/14/4525/2022/
* Made both DOIs (`Hydrography90m`, `hydrographr`) clickable

I checked both DOI links, they both work and point to the relevant pages:

* https://besjournals.onlinelibrary.wiley.com/doi/10.1111/2041-210X.14226
* https://essd.copernicus.org/articles/14/4525/2022/