### PR TITLE
Update reclass_raster function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ URL: https://glowabio.github.io/hydrographr/
 BugReports: https://github.com/glowabio/hydrographr/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.2
+RoxygenNote: 7.3.2
 Imports:
     processx (>= 3.7.0),
     data.table (>= 1.14.2),

--- a/R/reclass_raster.R
+++ b/R/reclass_raster.R
@@ -1,6 +1,6 @@
 #' @title Reclassify an integer raster layer
 #'
-#' @decription Reclassifies an integer raster .tif layer using the r.reclass
+#' @description Reclassifies an integer raster .tif layer using the r.reclass
 #' function of GRASS GIS. To reclassify the raster layer the present raster
 #' values and the new raster values have to be defined.
 #'
@@ -14,6 +14,9 @@
 #' @param rast_val character. The name of the column with the present
 #' raster values.
 #' @param new_val character. The name of the column with the new raster values.
+#' @param reclass_value integer. Value to reclassify the entire raster.
+#' Default is FALSE. Note in case reclass_value is provided, new_val parameter
+#' needs to be empty, otherwise the raster is reclassified based on the new_val column.
 #' @param raster_layer Full path to the input raster .tif layer.
 #' @param recl_layer character. Full path of the output .tif layer
 #' of the reclassified raster file.
@@ -32,7 +35,7 @@
 #' @importFrom terra rast
 #' @export
 #'
-#' @author Maria M. Üblacker
+#' @author Maria M. Üblacker, Thomas Tomiczek
 #'
 #' @references
 #' https://grass.osgeo.org/grass82/manuals/r.reclass.html
@@ -45,10 +48,8 @@
 #' download_test_data(my_directory)
 #'
 #' # Read the stream order for each sub-catchment as a data.table
-#' my_dt <- read_geopackage(gpkg= paste0(my_directory,
-#'                                          "/hydrography90m_test_data",
-#'                                          "/order_vect_1264942.gpkg"),
-#'                          import_as = "data.table")
+#' # my_dt <- read_geopackage(paste0(my_directory, "/order_vect_59.gpkg"),
+#' type = "net", as_dt = T)
 #'
 #'
 #' # Select the stream segment ID and and the Strahler stream order
@@ -68,45 +69,62 @@
 #'                                raster_layer = stream_raster,
 #'                                recl_layer = recl_raster)
 #'
+# Reclassify the stream network with the value 1 across the network
+#' str_ord_rast <- reclass_raster(data = str_ord$stream,
+#'                                reclass_value = 1,
+#'                                rast_val = "stream",
+#'                                raster_layer = stream_raster,
+#'                                recl_layer = recl_raster)
 
-
-reclass_raster <- function(data, rast_val, new_val, raster_layer,
-                           recl_layer, read = TRUE,
+reclass_raster <- function(data, rast_val, new_val = FALSE, raster_layer,
+                           recl_layer, reclass_value = FALSE,
                            no_data = -9999, type = "Int32",
-                           compress = "DEFLATE", quiet = TRUE) {
+                           compression = "low", bigtiff = TRUE,
+                           read = FALSE, quiet = TRUE) {
   # Check operating system
   system <- get_os()
   # Check if data.frame is defined
   if (missing(data))
     stop("data: Input data.frame is missing.")
 
-  # Check if input data is of type data.frame,
-  # data.table or tibble
+  # Check if input data is of type data.frame, data.table or tibble
   if (!is(data, "data.frame"))
     stop("data: Has to be of class 'data.frame'.")
 
-  # Check if rast_val and new_val is defined
+  # Check if rast_val is defined
   if (missing(rast_val))
     stop("rast_val: Column name of current raster value is missing.")
-  if (missing(new_val))
-    stop("new_val: Column name of new raster value is missing.")
 
-  # Check if rast_val/new_val column names exist
+  # Check if rast_val column names exist
   if (is.null(data[[rast_val]]))
     stop(paste0("rast_val: Column name '", rast_val,
     "' does not exist."))
-  if (is.null(data[[new_val]]))
-    stop(paste0("new_val: Column name '", new_val,
-    "' does not exist."))
 
-  # Check if values of the rast_val/new_val columns are numeric
+  # Check if values of the rast_val columns are numeric
   if (!is.integer(data[[rast_val]]))
     stop(
       paste0("rast_val: Values of column ", rast_val,
       " have to be integers."))
-  if (!is.integer(data[[new_val]]))
-    stop(paste0("new_val: Values of column ", new_val,
-    " have to be integers."))
+
+  # Check if new_val column names exist when no reclass_values is given
+  if (isFALSE(new_val) && isFALSE(reclass_value))
+    stop(paste0("new_val: Column name '", new_val,
+                "' does not exist."))
+
+  # Check if values of the new_val columns are numeric when no reclass_values is given
+  if (isFALSE(reclass_value)) {
+    if (!is.integer(data[[new_val]])) {
+      stop(paste0("reclass_value:", reclass_value, " must be integers."))
+    }
+
+  }
+
+  # Check if reclass_value is an numeric or integer value
+    if (!isFALSE(reclass_value)) {
+      if (!(is.numeric(reclass_value) || is.integer(reclass_value))) {
+        stop(paste0("reclass_value:", reclass_value, " must be integers."))
+      }
+    }
 
   # Check if raster_layer is defined
   if (missing(raster_layer))
@@ -136,9 +154,29 @@ reclass_raster <- function(data, rast_val, new_val, raster_layer,
     stop("type: Has to be 'Byte', 'Int16', 'UInt16', 'Int32', 'UInt32',
     'CInt16', or 'CInt32' ")
 
-  # Check if compress is "DEFLATE" or "LZW"
-  if (!(compress == "DEFLATE" || compress == "LZW"))
-    stop("compress: Has to be 'DEFLATE or 'LZW'.")
+  # Check and translate compression into the compression type and the
+  # compression level which is applied to the tiff file when writing it.
+  if(compression == "none") {
+    compression_type  <- "NONE"
+    compression_level <- 0
+  } else if (compression == "low") {
+    compression_type  <- "DEFLATE"
+    compression_level <- 2
+  } else if (compression == "high") {
+    compression_type  <- "DEFLATE"
+    compression_level <- 9
+  } else {
+    stop("'compression' must be one of 'none', 'low', or 'high'.")
+  }
+
+  # Define whether BIGTIFF is used or not. BIGTIFF is required for
+  # tiff output files > 4 GB.
+  if(bigtiff) {
+    bigtiff <- "YES"
+  } else {
+    bigtiff <- "NO"
+  }
+
 
   # Check if quiet is logical
   if (!is.logical(quiet))
@@ -147,12 +185,98 @@ reclass_raster <- function(data, rast_val, new_val, raster_layer,
   # Make bash scripts executable
   make_sh_exec()
 
-  # The r.reclass function of GRASS GIS requires a text file
-  # including the old and the new value with an = between
-  # (e.g. 1 = 20)
-  rules <- data.table(old = data[[rast_val]],
-                      equal = "=",
-                      new = data[[new_val]])
+  # To check the raster values and data values
+  # load raster and convert to data.frame
+  rast_dat <- rast(raster_layer)
+  rast_dat <- as.data.frame(rast_dat)
+  rast_dat <- as.data.frame(unique(rast_dat[[1]]))
+  colnames(rast_dat) <- "val"
+
+    # Check if rast_val is missing raster values
+    if (length(data[[rast_val]]) < length(rast_dat[[1]])) {
+      print("Reclassification is missing raster values: Warning NA's are introduced!")
+    }
+    # Check and handle if raster values are provided in rast_val that are not in the raster tif file.
+    if (length(data[[rast_val]]) != length(rast_dat[[1]])) {
+    # Index all raster values which are not in the input data table
+    indx_miss_raster <- which(rast_dat[[1]] %in% data[[rast_val]])
+    # Get missing raster values
+    miss_raster <- rast_dat[-c(indx_miss_raster),]
+    print(paste0("These values of the raster were not found in the data table:", paste(miss_raster, collapse = ", ")))
+    # Write all values found in raster tif file and input data table as data frame
+    same_val1 <- as.data.frame(rast_dat[c(indx_miss_raster),])
+    # Set name for raster values
+    colnames(same_val1) <- "val"
+    # Index all input data table values which are not in the raster tif file
+    indx_miss_rast_val <- which(data[[rast_val]] %in% rast_dat[[1]])
+    # Get missing input data values
+    miss_rast_val <- data[-c(indx_miss_rast_val),]
+    # Get only missing raster input data values to throw out message
+    missing_rast_values <- data[-c(indx_miss_rast_val),1]
+    print(paste0("These raster values of the data table were not found in the raster:", paste(missing_rast_values, collapse = ", ")))
+    # Write all values found in input data table and raster file as data frame
+    same_val2 <- data[c(indx_miss_raster),]
+    # Combine all values found in raster and input data table
+    same_val <- as.data.frame(cbind(same_val1, same_val2))
+    # Write missing raster values as data frame
+    miss_raster <- as.data.frame(miss_raster)
+    # Set name for raster values
+    colnames(miss_raster) <- "val"
+    # Give missing values NA
+    miss_raster$rast_val <- NA
+    miss_raster$new_val <- NA
+    # Set to the same names to combine with all values table
+    colnames(miss_raster) <- c("val", rast_val, new_val)
+    # Combine all values table with missing values table and use as input data
+    data <- rbind(same_val, miss_raster)
+
+    # List both rast_val and new_val columns to check if they are of equal length
+    dat <- list(data[[rast_val]], list(data[[new_val]]))
+
+    # In case new_val is bigger than rast_val length of rast_val will be used to reclassify
+    data <- setNames(do.call(cbind.data.frame,
+                            lapply(lapply(dat, unlist),
+                                   `length<-`, max(lengths(dat)))), paste0(c(rast_val, new_val)))
+    if (isFALSE(reclass_value)) {
+    # The r.reclass function of GRASS GIS requires a text file
+    # including the old and the new value with an = between
+    # (e.g. 1 = 20)
+    rules <- data.table::data.table(old = data[[rast_val]],
+                                    equal = "=",
+                                    new = data[[new_val]])
+    }
+  }
+
+  if (!isFALSE(reclass_value)) {
+
+  # use reclass_value for reclassification
+    data$reclass <- reclass_value
+    data$reclass <- as.integer(data$reclass)
+    #
+    #
+    #
+    #
+    #
+    # rand_string <- stri_rand_strings(n = 1, length = 8, pattern = "[A-Za-z0-9]")
+    # rules_path <- paste0(tempdir(), "/reclass_rules_", rand_string, ".txt")
+    # fwrite(data, rules_path, sep = " ", col.names = TRUE)
+
+    # The r.reclass function of GRASS GIS requires a text file
+    # including the old and the new value with an = between
+    # (e.g. 1 = 20)
+    rules <- data.table::data.table(old = data[[rast_val]],
+                                    equal = "=",
+                                    new = data[["reclass"]])
+   }
+  # else {
+  #
+  # # The r.reclass function of GRASS GIS requires a text file
+  # # including the old and the new value with an = between
+  # # (e.g. 1 = 20)
+  # rules <- data.table::data.table(old = data[[rast_val]],
+  #                     equal = "=",
+  #                     new = data[[new_val]])
+  # }
   # Create random string to attach to the file name of the temporary
   # rules .txt file
   rand_string <- stri_rand_strings(n = 1, length = 8, pattern = "[A-Za-z0-9]")
@@ -161,13 +285,17 @@ reclass_raster <- function(data, rast_val, new_val, raster_layer,
   # Write rules as a .txt file to the temporary folder
   fwrite(rules, rules_path, sep = " ", col.names = FALSE)
 
+  # Remove all temporary data files
+  rm(indx_miss_raster, miss_raster, same_val1, indx_miss_rast_val,
+     miss_rast_val, missing_rast_values, same_val2, same_val)
+
   if (system == "linux" || system == "osx") {
   # Open GRASS GIS session
   # Call external GRASS GIS command r.reclass
   processx::run(system.file("sh", "reclass_raster.sh",
                            package = "hydrographr"),
       args = c(raster_layer, rules_path, recl_layer,
-                             no_data, type, compress),
+               no_data, type, compression_type, compression_level, bigtiff),
       echo = !quiet)
 
   } else {
@@ -179,27 +307,33 @@ reclass_raster <- function(data, rast_val, new_val, raster_layer,
     wsl_rules_path <- fix_path(rules_path)
     wsl_sh_file <- fix_path(
       system.file("sh", "reclass_raster.sh",
-                            package = "hydrographr"))
+                  package = "hydrographr"))
 
     # Open GRASS GIS session on WSL
     # Call external GRASS GIS command r.reclass
     processx::run(system.file("bat", "reclass_raster.bat",
-                    package = "hydrographr"),
-        args = c(wsl_raster_layer, wsl_rules_path, wsl_recl_layer,
-                 no_data, type, compress, wsl_sh_file),
-        echo = !quiet)
+                              package = "hydrographr"),
+                  args = c(wsl_raster_layer, wsl_rules_path, wsl_recl_layer,
+                           no_data, type, compression_type, compression_level, bigtiff,
+                           wsl_sh_file),
+                  echo = !quiet)
 
   }
   # Remove temporary rules file
   file.remove(rules_path)
 
+  if (file.exists(recl_layer)) {
+    # Print message
+    cat("Reclassified raster saved under: ", recl_layer, "\n")
+  } else {
+    stop("Output file was not written. File size may have been larger than 4GB",
+         "\nSet bigtiff = TRUE, for writing large output files.")
+  }
+
   if (read == TRUE) {
     # Read reclassified .tif layer
     recl_rast <- rast(recl_layer)
-
-  } else {
-   # Print message
-   print(paste0("Reclassified raster saved under: ", recl_layer))
+    return(recl_rast)
   }
 
 }

--- a/inst/bat/reclass_raster.bat
+++ b/inst/bat/reclass_raster.bat
@@ -1,9 +1,9 @@
 @echo on
 
-set WSLENV=%1 %2 %3 %4 %5 %6
+set WSLENV=%1 %2 %3 %4 %5 %6 %7 %8 %9
 set RULES=%2
-set SHDIR=%7
+set SHDIR=%9
 
 wsl dos2unix %RULES%
-wsl dos2unix %SHDIR% 
+wsl dos2unix %SHDIR%
 wsl bash  %SHDIR% $WSLENV

--- a/inst/sh/reclass_raster.sh
+++ b/inst/sh/reclass_raster.sh
@@ -5,21 +5,23 @@ export RULES=$2
 export OUTPUT=$3
 export NODATA=$4
 export TYPE=$5
-export COMP=$6
+export COMPRESSION=$6
+export LEVEL=$7
+export BTIFF=$8
+
 
 # Start GRASS GIS session
-grass -f --text --tmp-location  $RASTER   <<'EOF'
-    
-    # Load raster input file	
+grass -f --gtext --tmp-location  $RASTER   <<'EOF'
+
+    # Load raster input file
     r.in.gdal --o input=$RASTER  output=raster    --overwrite
-    
-    # Reclassify the raster according to the rules		
+
+    # Reclassify the raster according to the rules
     r.reclass input=raster output=recl_raster rules=$RULES --overwrite
 
     # Export reclassified raster map
-    r.out.gdal input=recl_raster output=$OUTPUT type=$TYPE  format=GTiff nodata=$NODATA  --o -f -m -c createopt="COMPRESS=$COMP" 
+    r.out.gdal input=recl_raster output=$OUTPUT type=$TYPE  format=GTiff nodata=$NODATA  --o -f -m -c createopt="COMPRESS=$COMPRESSION,ZLEVEL=$LEVEL,BIGTIFF=$BTIFF"
 
-# done
 EOF
 
 exit

--- a/man/reclass_raster.Rd
+++ b/man/reclass_raster.Rd
@@ -7,13 +7,15 @@
 reclass_raster(
   data,
   rast_val,
-  new_val,
+  new_val = FALSE,
   raster_layer,
   recl_layer,
-  read = TRUE,
+  reclass_value = FALSE,
   no_data = -9999,
   type = "Int32",
-  compress = "DEFLATE",
+  compression = "low",
+  bigtiff = TRUE,
+  read = FALSE,
   quiet = TRUE
 )
 }
@@ -31,9 +33,9 @@ raster values.}
 \item{recl_layer}{character. Full path of the output .tif layer
 of the reclassified raster file.}
 
-\item{read}{logical. If TRUE, then the reclassified raster .tif layer
-gets read into R as a SpatRaster (terra object).
-If FALSE, the layer is only stored on disk. Default is TRUE.}
+\item{reclass_value}{integer. Value to reclassify the entire raster.
+Default is FALSE. Note in case reclass_value is provided, new_val parameter
+needs to be empty, otherwise the raster is reclassified based on the new_val column.}
 
 \item{no_data}{numeric. The no_data value of the new .tif layer.
 Default is -9999.}
@@ -41,10 +43,21 @@ Default is -9999.}
 \item{type}{character. Data type; Options are Byte, Int16, UInt16, Int32,
 UInt32,CInt16, CInt32. Default is Int32.}
 
+\item{read}{logical. If TRUE, then the reclassified raster .tif layer
+gets read into R as a SpatRaster (terra object).
+If FALSE, the layer is only stored on disk. Default is TRUE.}
+
 \item{compress}{Compression type: DEFLATE or LZW. Default is DEFLATE.}
 }
 \description{
-Reclassify an integer raster layer
+Reclassifies an integer raster .tif layer using the r.reclass
+function of GRASS GIS. To reclassify the raster layer the present raster
+values and the new raster values have to be defined.
+
+If the input raster layer has floating point values, you should multiply
+the input data by some factor (e.g. 1000) to achieve integer values,
+otherwise the GRASS GIS r.reclass will round the raster values down to
+the next integer which is not always desired.
 }
 \examples{
 # Download test data into the temporary R folder
@@ -53,10 +66,8 @@ my_directory <- tempdir()
 download_test_data(my_directory)
 
 # Read the stream order for each sub-catchment as a data.table
-my_dt <- read_geopackage(gpkg= paste0(my_directory,
-                                         "/hydrography90m_test_data",
-                                         "/order_vect_1264942.gpkg"),
-                         import_as = "data.table")
+# my_dt <- read_geopackage(paste0(my_directory, "/order_vect_59.gpkg"),
+type = "net", as_dt = T)
 
 
 # Select the stream segment ID and and the Strahler stream order
@@ -76,10 +87,15 @@ str_ord_rast <- reclass_raster(data = str_ord,
                                raster_layer = stream_raster,
                                recl_layer = recl_raster)
 
+str_ord_rast <- reclass_raster(data = str_ord$stream,
+                               reclass_value = 1,
+                               rast_val = "stream",
+                               raster_layer = stream_raster,
+                               recl_layer = recl_raster)
 }
 \references{
 https://grass.osgeo.org/grass82/manuals/r.reclass.html
 }
 \author{
-Maria M. Üblacker
+Maria M. Üblacker, Thomas Tomiczek
 }


### PR DESCRIPTION
Function now handles differences between raster values of the tif file and reclass input table by introducing NAs for values in the raster not found in the input table and not using values of the input table not found in the raster. Note: that all changes in the bat and sh file are due to an old dev_reclass raster branch and all updates are based on the main branch.