### PR TITLE
Fix get predict table

### DIFF
--- a/R/get_predict_table.R
+++ b/R/get_predict_table.R
@@ -100,8 +100,14 @@ get_predict_table <- function(variable,
     stop("Please provide the path to a file
      containing subcatchment IDs (parameter \"subcatch_id\").")
 
-  if (!file.exists(subcatch_id))
+  if(is.numeric(subcatch_id)) {
+    stop("You provided subcatchment IDs, but you should provide a path",
+      " to a file containing subcatchment IDs!")
+  } else {
+    if (!quiet) message(paste0("INFO: You provided the path to a table containing subcatchment IDs."))
+    if (!file.exists(subcatch_id))
       stop(paste0("Path: ", subcatch_id, " does not exist."))
+  }
 
   if (missing(out_file_path))
     stop("Please provide a path to the output file (parameter \"out_file_path\").")

--- a/R/get_predict_table.R
+++ b/R/get_predict_table.R
@@ -101,7 +101,7 @@ get_predict_table <- function(variable,
     the entire tiles (parameter \"input_var_path\").")
 
   if (missing(subcatch_id))
-    stop("Please provide the path to a file
+    stop("Please provide at least one subcatchment ID or a path to a file
      containing subcatchment IDs (parameter \"subcatch_id\").")
 
   if(is.numeric(subcatch_id)) {
@@ -119,8 +119,9 @@ get_predict_table <- function(variable,
 
   # If the result file already exists, stop or warn user:
   if (file.exists(out_file_path)) {
+
+    # It is a not a file, but a directory!
     if (dir.exists(out_file_path)) {
-      # It is a not a file, but a directory!
       stop("Please provide a path to an output file. You passed a path to a directory: ",
         out_file_path)
     }
@@ -137,7 +138,7 @@ get_predict_table <- function(variable,
   }
 
   # If the result file does not exist, check whether it can be created
-  # (to prevent errors later)
+  # (to prevent errors later):
   if (!file.exists(out_file_path)) {
 
     # Trying to write to a file that ends in a slash causes an error in the bash script:
@@ -185,10 +186,10 @@ get_predict_table <- function(variable,
   }
 
   # Check if statistics name provided is one of the accepted values
-  if (any(!(statistics %in% "ALL"))) {
-    if (any(!(statistics %in% c("sd", "mean", "range"))))
-      stop("Please provide a valid statistics name. Possible values are
-             sd, mean, range or ALL")
+  accepted_stats = c("ALL","sd", "mean", "range")
+  if (any(!(statistics %in% accepted_stats))) {
+    stop("Please provide a valid statistics name. Possible values are: ",
+         paste0(accepted_stats, collapse=", "), ".")
   }
 
   # Check if n_cores is numeric
@@ -207,8 +208,8 @@ get_predict_table <- function(variable,
   # already present in temp):
   # Check variable name is one of the accepted values
   #if (!quiet) message("Checking the variable names against the list(s) of allowed variable names...")
-  if (!quiet) message(paste("Downloading the list(s) of allowed variable names,",
-    "unless they were already downloaded to your temp directory..."))
+  if (!quiet) message("INFO: Downloading the list(s) of allowed variable names,",
+                      "unless they were already downloaded to your temp directory...")
   # TODO: This download is potentially noisy. Make it (possibly) quiet? Really quiet?
   accepted_vars <- c(
     download_observed_climate_tables(download=FALSE, quiet=TRUE, tempdir=tempdir)$variable_names,
@@ -264,7 +265,7 @@ get_predict_table <- function(variable,
 
   # Make bash scripts executable
   make_sh_exec()
-  if (!quiet) message("Running bash script...")
+  if (!quiet) message("INFO: Running bash script...")
   if (sys_os == "linux" || sys_os == "osx") {
     # Call external bash script
     processx::run(system.file("sh", "get_predict_table.sh",
@@ -304,14 +305,14 @@ get_predict_table <- function(variable,
                            wsl_sh_file))
 
   }
-  if (!quiet) message("Running bash script: Done.")
+  if (!quiet) message("INFO: Running bash script: Done.")
 
 
   # Delete temporary output directory
   unlink(tmp_dir, recursive = TRUE)
 
   if (read == TRUE) {
-    if (!quiet) message("Reading result table from ", out_file_path)
+    if (!quiet) message("INFO: Reading result table from ", out_file_path)
     predict_table <- fread(out_file_path)
     return(predict_table)
   }

--- a/R/get_predict_table.R
+++ b/R/get_predict_table.R
@@ -22,6 +22,8 @@
 #' Default is TRUE.
 #' @param tempdir String. Path to the directory where to store/look for the
 #'  file size table. If not passed, defaults to the output of [base::tempdir()].
+#' @param overwrite logical. If TRUE, the output file will be overwritten if it.
+#' already exists. Useful for repeated testing. Default is FALSE.
 #' @importFrom processx run
 #' @importFrom stringi stri_rand_strings
 #' @importFrom stringi stri_rand_strings
@@ -75,7 +77,8 @@ get_predict_table <- function(variable,
                               n_cores = NULL,
                               read = TRUE,
                               quiet = TRUE,
-                              tempdir = NULL) {
+                              tempdir = NULL,
+                              overwrite = FALSE) {
 
   # Define tempdir:
   if (is.null(tempdir)) {
@@ -118,10 +121,16 @@ get_predict_table <- function(variable,
       # It is a not a file, but a directory!
       stop("Please provide a path to an output file. You passed a path to a directory: ",
         out_file_path)
-    } else {
-      # It is a file, and it exists! # TODO: Should we stop?
-      message("INFO: Result will overwrite existing file: ", out_file_path)
-      warning("Result will overwrite existing file: ", out_file_path)
+    }
+
+    # It is a file, and it exists already!
+    else {
+      if (overwrite) {
+        message("INFO: Result will overwrite existing file: ", out_file_path)
+      } else {
+        stop("Output file already exists (cannot overwrite): ", out_file_path,
+             "\n  (if you want to overwrite, set \"overwrite=TRUE\").")
+      }
     }
   }
 

--- a/R/get_predict_table.R
+++ b/R/get_predict_table.R
@@ -112,9 +112,18 @@ get_predict_table <- function(variable,
     for (itile in tile_id) {
       filename <- paste0(ivar, "_", itile, ".txt")
       if (filename %in% basename(list.files(input_var_path, recursive=TRUE))) {
-        if (!quiet) message("INFO: Input table exists: ", filename)
+        #if (!quiet) message("INFO: Input table exists: ", filename)
       } else {
         stop("Input table does not exist: ", filename, " (in subdirectory of: ", input_var_path, ")")
+      }
+      # The following loop is not necessary. It finds the path of each file,
+      # which is not required but just nice, for the user's convenience:
+      for (somepath in list.files(input_var_path, recursive=TRUE)) {
+        somename <- basename(somepath)
+        if (somename==filename) {
+          if (!quiet) message("INFO: Input table exists: ", filename,
+                              " (here: ", file.path(input_var_path, somepath), ")")
+        }
       }
     }
   }

--- a/R/get_predict_table.R
+++ b/R/get_predict_table.R
@@ -106,15 +106,15 @@ get_predict_table <- function(variable,
   if (!file.exists(input_var_path))
     stop(paste0("Path: ", input_var_path, " does not exist."))
 
-  # Check if input tables exist:
+  # Check if input tables exist somewhere in a subdir of input_var_path:
   # This only works if the files have this name pattern!
   for (ivar in variable) {
     for (itile in tile_id) {
-      ipath <- file.path(input_var_path, paste0(ivar, "_", itile, ".txt"))
-      if (file.exists(ipath)) {
-        if (!quiet) message("Input table exists: ", ipath)
+      filename <- paste0(ivar, "_", itile, ".txt")
+      if (filename %in% basename(list.files(input_var_path, recursive=TRUE))) {
+        if (!quiet) message("INFO: Input table exists: ", filename)
       } else {
-        stop(paste0("Input table: does not exist: ", ipath))
+        stop("Input table does not exist: ", filename, " (in subdirectory of: ", input_var_path, ")")
       }
     }
   }

--- a/R/get_predict_table.R
+++ b/R/get_predict_table.R
@@ -97,7 +97,8 @@ get_predict_table <- function(variable,
     the entire tiles (parameter \"input_var_path\").")
 
   if (missing(subcatch_id))
-    stop("Please provide at least one subcatchment ID (parameter \"subcatch_id\").")
+    stop("Please provide the path to a file
+     containing subcatchment IDs (parameter \"subcatch_id\").")
 
   if (missing(out_file_path))
     stop("Please provide a path to the output file (parameter \"out_file_path\").")

--- a/R/get_predict_table.R
+++ b/R/get_predict_table.R
@@ -112,6 +112,41 @@ get_predict_table <- function(variable,
   if (missing(out_file_path))
     stop("Please provide a path to the output file (parameter \"out_file_path\").")
 
+  # If the result file already exists, stop or warn user:
+  if (file.exists(out_file_path)) {
+    if (dir.exists(out_file_path)) {
+      # It is a not a file, but a directory!
+      stop("Please provide a path to an output file. You passed a path to a directory: ",
+        out_file_path)
+    } else {
+      # It is a file, and it exists! # TODO: Should we stop?
+      message("INFO: Result will overwrite existing file: ", out_file_path)
+      warning("Result will overwrite existing file: ", out_file_path)
+    }
+  }
+
+  # If the result file does not exist, check whether it can be created
+  # (to prevent errors later)
+  if (!file.exists(out_file_path)) {
+
+    # Trying to write to a file that ends in a slash causes an error in the bash script:
+    # "cp: cannot create regular file './testfile/': Not a directory"
+    if (endsWith(out_file_path, "/")) {
+      stop("Please provide a path to an output file. You passed a path to a directory: ",
+        out_file_path)
+    }
+
+    # The directory in which we want to write the output has to exist:
+    if (dir.exists(dirname(out_file_path))) {
+      if (!quiet) message("INFO: Output will be written to ", out_file_path)
+    } else {
+      stop("Cannot create output file \"", basename(out_file_path), "\".",
+           " We can only write output to an existing directory.",
+           " Directory does not exist: ", dirname(out_file_path)
+      )
+    }
+  }
+
   # Check if paths exists
   if (!file.exists(input_var_path))
     stop(paste0("Path: ", input_var_path, " does not exist."))

--- a/R/get_predict_table.R
+++ b/R/get_predict_table.R
@@ -100,6 +100,9 @@ get_predict_table <- function(variable,
     stop("Please provide the path to a file
      containing subcatchment IDs (parameter \"subcatch_id\").")
 
+  if (!file.exists(subcatch_id))
+      stop(paste0("Path: ", subcatch_id, " does not exist."))
+
   if (missing(out_file_path))
     stop("Please provide a path to the output file (parameter \"out_file_path\").")
 


### PR DESCRIPTION
I added several things!

First of all, **fixed the bug that Jaime noticed:** When checking whether the input tables exist, the function only looked into the directory the user provided (e.g. `/input_dir/bio1_h18v04.txt`). But the download functions make quite a directory hierarchy (e.g. `/input_dir/chelsa_bioclim_v2_1/1981-2010_observed/bio1/bio1_h18v04.txt`). Jaime's bash script checks subdirectories - and now the check in this R function does, too.

More things:

* Checking whether the output path the user provided is valid (directory has to exist, but file shouldn't)
* Checking whether the input subcatchment txt file exists.
* Allow users to specify whether they want to overwrite result files or not (default: not, new parameter `overwrite`).
* Allow users to pass subcatchment ids directly (`c(513988454, 513987288, 513986120)`), probably most useful for testing.

I tested all of this, but feel free to test again. 