### PR TITLE
Let users define temp dir, to prevent re-downloading regional_unit_ovr.tif in every R session

### DIFF
--- a/R/get_regional_unit_id.R
+++ b/R/get_regional_unit_id.R
@@ -13,6 +13,7 @@
 #' @param lat character. The name of the column with the latitude coordinates.
 #' @param quiet logical. If FALSE, the standard output will be printed.
 #' Default is TRUE.
+#' @param tempdir character. The directory to be used as temp folder. Optional.
 #' @importFrom stringi stri_rand_strings
 #' @importFrom dplyr select
 #' @importFrom data.table fread
@@ -44,7 +45,7 @@
 # provide points as an input and get the regional units
 # where the points belong (without the full extent)
 
-get_regional_unit_id <- function(data, lon, lat, quiet = TRUE) {
+get_regional_unit_id <- function(data, lon, lat, quiet = TRUE, tempdir = NULL) {
 
   # Check if input data is of type data.frame,
   # data.table or tibble
@@ -73,8 +74,11 @@ get_regional_unit_id <- function(data, lon, lat, quiet = TRUE) {
   # Increase time to allow downloading the reg unit file
   options(timeout = max(300, getOption("timeout")))
 
+  # Use tempdir passed by user, or the default one:
+  if (is.null(tempdir)) { tempdir <- tempdir() }
+
   # global file of regional units ids
-  reg_unit_file <- paste0(tempdir(), "/regional_unit_ovr.tif")
+  reg_unit_file <- paste0(tempdir, "/regional_unit_ovr.tif")
 
   # define download paths (two options):
   nimbus_url_base <- "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2F"
@@ -154,14 +158,14 @@ get_regional_unit_id <- function(data, lon, lat, quiet = TRUE) {
     select(matches(c(lon, lat)))
 
   # Export taxon occurrence points
-  coord_tmp_path <- paste0(tempdir(), "/coordinates_", rand_string, ".txt")
+  coord_tmp_path <- paste0(tempdir, "/coordinates_", rand_string, ".txt")
 
   ## Note:Only export lon/lat column
   fwrite(coord, coord_tmp_path, col.names = TRUE,
          row.names = FALSE, quote = FALSE, sep = " ")
 
   # Path where tmp regional unit ids text file will be written
-  ids_tmp_path <- paste0(tempdir(), "/reg_unit_ids", rand_string, ".txt")
+  ids_tmp_path <- paste0(tempdir, "/reg_unit_ids", rand_string, ".txt")
 
   # Check operating system
   sys_os <- get_os()

--- a/R/get_tile_id.R
+++ b/R/get_tile_id.R
@@ -10,6 +10,7 @@
 #' the longitude / latitude coordinates in WGS84.
 #' @param lon character. The name of the column with the longitude coordinates.
 #' @param lat character. The name of the column with the latitude coordinates.
+#' @param tempdir character. The directory to be used as temp folder. Optional.
 #' @importFrom data.table fread
 #' @export
 #'
@@ -32,18 +33,23 @@
 #'             lon = "longitude", lat = "latitude")
 
 
-get_tile_id <- function(data, lon, lat) {
+get_tile_id <- function(data, lon, lat, tempdir=NULL) {
 
-  reg_un <- get_regional_unit_id(data, lon, lat)
+  reg_un <- get_regional_unit_id(data, lon, lat, tempdir=tempdir)
+  # TODO: Replace in all internal calls of get_regional_unit_id and get_tile_id!
 
+  # Use tempdir passed by user, or the default one:
+  if (is.null(tempdir)) { tempdir <- tempdir() }
 
-  lookup_file <- paste0(tempdir(), "/lookup_tile_regunit.txt")
+  lookup_file <- paste0(tempdir, "/lookup_tile_regunit.txt")
 
   if (!file.exists(lookup_file)) {
     download.file("https://drive.google.com/uc?export=download&id=1deKhOEjGgvUXPwivYyH99hgHlJV7OgUv&confirm=t",
                   destfile = lookup_file,
                   quiet = FALSE)
 
+  } else {
+    message(paste("Will use this file (already downloaded):", lookup_file))
   }
 
   lookup <- fread(lookup_file)


### PR DESCRIPTION
Let users **pass the tempdir** in `get_tile_id(...)` and `get_regional_id(...)`, so that the lookup files (`lookup_tile_regunit.txt`, `regional_unit_ovr.tif`) dont have to be downloaded again in every R session.

This was developed for our Livingdata Workshop, where we could pre-store the files that hydrographr would download into the pre-defined temp dir. But it is useful for anyone using hydrographr more than once without wanting to re-download them again and again, as R defines a new temp dir in every session.

Note that this affects also where user-specific files are stored to (e.g. taxon occurrence points `coordinates_xyz123.txt` and regional unit ids `reg_unit_idsxyz123.txt`, downloaded during `get_regional_unit_id(...)`), but as they get assigned a random string, there is no danger of older temp files interfering with newer ones.
