### PR TITLE
Fix bug windows get_lake_catchment.R

### DIFF
--- a/R/get_lake_catchment.R
+++ b/R/get_lake_catchment.R
@@ -125,7 +125,8 @@ get_lake_catchment <- function(data, flow = "flow_accu_mean",
     processx::run(system.file("bat", "get_lake_catchment.bat",
                               package = "hydrographr"),
                   args = c(wsl_lak_tmp_path, lake_id, wsl_direction, wsl_tmp_path,
-                           wsl_lake_basin, n_cores, wsl_sh_file, echo = !quiet))
+                           wsl_lake_basin, n_cores, wsl_sh_file),
+                           echo = !quiet)
 
   }
   # Return message


### PR DESCRIPTION
Moved the echo = !quiet outside of the argument list to run processx for windows. This led to the incorrect number of arguments passed to the bat file and the function was not executed in windows. This has been fixed now by moving it outside the argument list.